### PR TITLE
Add additional include paths to libs.zig

### DIFF
--- a/libs.zig
+++ b/libs.zig
@@ -63,6 +63,8 @@ fn linkToOpenCV(exe: *std.build.LibExeObjStep) void {
             exe.linkSystemLibrary("c");
         },
         else => {
+            exe.addIncludePath("/usr/include");
+            exe.addIncludePath("/usr/include/opencv4");
             exe.addIncludePath("/usr/local/include");
             exe.addIncludePath("/usr/local/include/opencv4");
             exe.addIncludePath("/opt/homebrew/include");


### PR DESCRIPTION
For when opencv libs are installed via a system package manager it'll be in /usr/include not /usr/local/include