### PR TITLE
fix(ci): update devenv config for current CLI

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -3,17 +3,11 @@
 let
   zigVersion = "0.11.0";
 
-  zigOverlayPkgs =
-    if builtins.hasAttr pkgs.system inputs."zig-overlay".packages then
-      builtins.getAttr pkgs.system inputs."zig-overlay".packages
-    else
-      throw "zig-overlay does not provide packages for this system";
-
   zigPackage =
-    if builtins.hasAttr zigVersion zigOverlayPkgs then
-      builtins.getAttr zigVersion zigOverlayPkgs
+    if builtins.hasAttr "zig_0_11" pkgs then
+      pkgs.zig_0_11
     else
-      throw "zig-overlay does not provide Zig ${zigVersion} for this system";
+      throw "nixpkgs does not provide Zig ${zigVersion}";
 
   zlsPackages =
     if inputs ? zls && inputs.zls ? packages && builtins.hasAttr pkgs.system inputs.zls.packages then
@@ -73,7 +67,7 @@ in
       })
   ];
 
-  # devenv 1.9's tasks helper requires nightly Cargo; stub it out to avoid the build.
+  # Avoid evaluating the pinned devenv module's bundled tasks helper.
   task.package = pkgs.writeShellScriptBin "devenv-tasks" ''
     exit 0
     '';

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -9,5 +9,12 @@ inputs:
         follows: nixpkgs
   nixpkgs-opencv-4-6:
     url: github:NixOS/nixpkgs/nixos-22.11
+  git-hooks:
+    url: github:cachix/git-hooks.nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  pre-commit-hooks:
+    follows: git-hooks
   zls:
     url: github:zigtools/zls

--- a/nix/models.nix
+++ b/nix/models.nix
@@ -1,7 +1,7 @@
 { pkgs }:
 let
   caffeModel = pkgs.fetchurl {
-    url = "http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel";
+    url = "https://web.archive.org/web/20250115134433/http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel";
     hash = "sha256-b3EB46IYNzinEloMUCG6gqH+tCKMXKCSTZkbba9vb60=";
   };
 


### PR DESCRIPTION
## Summary
  I noticed that CI has been failing for a while at the `devenv shell -- echo "Shell activated"` step.

  This pr aims to fix that.

  Changes:
  - Add explicit `git-hooks` / `pre-commit-hooks` inputs required by current devenv.
  - Use `pkgs.zig_0_11` from pinned nixpkgs instead of `zig-overlay` which seemed to be not reliable.
  - Keep the `task.package` stub, but update the comment on why it is still needed.
  - Fetch `bvlc_googlenet.caffemodel` through the Web Archive because the original Caffe host is unavailable.

  For the Caffe model URL change, the fixed output hash is unchanged, just fetched from archive URL. This is still not ideal and the model probably should be moved to more persistent mirror or
  the test could be changed to use a model with reliable upstream source.

  ## Verification
  Verified both locally with `devenv 2.1.2` and on fork through the existing Github Actions:
  https://github.com/IfkumRfnl/zigcv/actions/runs/26070295887